### PR TITLE
Update D1 database to boardgame-match-db

### DIFF
--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -4,8 +4,8 @@ compatibility_date = "2024-01-01"
 
 [[d1_databases]]
 binding = "DB"
-database_name = "mbti-board-game-matcher-db"
-database_id = "14005155-22c2-467d-84e5-9177222ea9bf"
+database_name = "boardgame-match-db"
+database_id = "f3387dc6-6fcb-4882-9a84-ddc4a40e6599"
 
 [vars]
 GOOGLE_CLIENT_ID = "105319270176-djqr0n6r4l3mvmpalsqjn8kasqii9ukt.apps.googleusercontent.com"


### PR DESCRIPTION
## Summary

- 將 wrangler.toml 的 D1 資料庫從 `mbti-board-game-matcher-db` 更新為新建的 `boardgame-match-db`
- 新 DB UUID: `f3387dc6-6fcb-4882-9a84-ddc4a40e6599`
- 已匯入完整資料（20 張表、8,499 筆遊戲、47 位使用者）
- Worker 已重新部署並設定 API_SECRET

## Test plan

- [ ] 確認 Worker 可正常存取新 D1 資料庫
- [ ] 確認 Nginx 已更新 `/tables/` proxy 設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)