### PR TITLE
Fix PUBLIC_READ_TABLES for public pages

### DIFF
--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -46,7 +46,8 @@ const PUBLIC_READ_TABLES = [
   'collection_game_stats', 'achievements', 'site_stats',
   'quiz_collections', 'quiz_questions', 'daily_quests',
   'limited_events', 'publisher_badge_series',
-  'user_collections', 'leaderboard'
+  'user_collections', 'users', 'user_stats',
+  'game_votes', 'user_collection_votes'
 ];
 
 const ADMIN_ONLY_TABLES = [


### PR DESCRIPTION
## Summary
- 將 `users`、`user_stats`、`game_votes`、`user_collection_votes` 加入 `PUBLIC_READ_TABLES`，允許未登入使用者讀取
- 移除不存在的 `leaderboard` 表項目

## 問題
explore、leaderboard、player、recommend 頁面不需登入即可瀏覽，但這些頁面所讀取的表原本設定為 `auth` 等級（需 JWT），導致未登入使用者無法載入頁面資料。

## 影響範圍
僅影響 GET 請求的權限判定，寫入操作（POST/PUT/DELETE）不受影響，仍需 JWT 驗證。

## Test plan
- [ ] 未登入狀態下開啟 explore 頁面，確認能正常載入玩家資料
- [ ] 未登入狀態下開啟 leaderboard 頁面，確認排行榜正常顯示
- [ ] 未登入狀態下開啟 player 頁面（帶 ?id=），確認玩家檔案正常顯示
- [ ] 未登入狀態下開啟 recommend 頁面，確認集合清單正常顯示
- [ ] 登入後確認寫入操作仍需驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)