### PR TITLE
Add admin-db-migrate.html database export tool

### DIFF
--- a/cloudflare/schema.sql
+++ b/cloudflare/schema.sql
@@ -24,6 +24,8 @@ CREATE TABLE IF NOT EXISTS users (
   last_login INTEGER,
   bio TEXT,
   social_links TEXT,
+  explore_list TEXT,
+  explore_list_public INTEGER DEFAULT 1,
   created_at INTEGER DEFAULT (strftime('%s','now') * 1000),
   updated_at INTEGER DEFAULT (strftime('%s','now') * 1000)
 );
@@ -92,6 +94,7 @@ CREATE TABLE IF NOT EXISTS game_collections (
   games TEXT DEFAULT '[]',
   icon TEXT,
   description TEXT,
+  games_cache TEXT,
   sort_order INTEGER DEFAULT 0,
   is_active INTEGER DEFAULT 1,
   start_date INTEGER,

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -268,10 +268,8 @@ export default {
         // 取得欄位列表
         const columns = await getTableColumns(db, tableName);
 
-        // 計算總數
-        const hasDeletedAt = !['site_stats', 'game_database', 'game_aliases', 'achievements',
-          'daily_quests', 'limited_events', 'admin_whitelist', 'tester_whitelist',
-          'influencer_whitelist', 'publisher_badge_series'].includes(tableName);
+        // 計算總數（若表有 deleted_at 欄位則自動過濾已刪除資料）
+        const hasDeletedAt = columns.includes('deleted_at');
         const whereBase = hasDeletedAt
           ? `WHERE (deleted_at IS NULL OR deleted_at = '')`
           : `WHERE 1=1`;

--- a/public/admin-db-migrate.html
+++ b/public/admin-db-migrate.html
@@ -1,0 +1,727 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>資料庫匯出 → SQL - MBTI × 桌遊配對</title>
+
+    <!-- Google Sign-In SDK -->
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+
+    <!-- 管理後台驗證 -->
+    <script src="js/admin-auth.js?v=20240222-fix"></script>
+    <script src="js/app.js"></script>
+    <script src="js/show-admin-link.js?v=20240222-fix"></script>
+    <script src="js/admin-navbar-cleanup.js"></script>
+
+    <style>
+        :root {
+            --bg: #0f172a;
+            --card: #1e293b;
+            --border: #334155;
+            --text: #e2e8f0;
+            --muted: #94a3b8;
+            --primary: #6366f1;
+            --success: #10b981;
+            --warn: #f59e0b;
+            --danger: #ef4444;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            background: var(--bg);
+            color: var(--text);
+            font-family: system-ui, sans-serif;
+            min-height: 100vh;
+            padding: 2rem 1rem;
+        }
+        .container { max-width: 860px; margin: 0 auto; }
+        h1 { font-size: 1.5rem; margin-bottom: 0.3rem; }
+        .subtitle {
+            color: var(--muted);
+            font-size: 0.85rem;
+            margin-bottom: 1.5rem;
+            line-height: 1.7;
+        }
+        .card {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 0.75rem;
+            padding: 1.5rem;
+            margin-bottom: 1.25rem;
+        }
+        .card-title {
+            font-size: 1rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.55rem 1.2rem;
+            border-radius: 0.5rem;
+            border: none;
+            cursor: pointer;
+            font-size: 0.88rem;
+            font-weight: 600;
+            transition: opacity 0.15s;
+        }
+        .btn:hover:not(:disabled) { opacity: 0.85; }
+        .btn:disabled { opacity: 0.35; cursor: not-allowed; }
+        .btn-primary { background: var(--primary); color: #fff; }
+        .btn-success { background: var(--success); color: #fff; }
+        .btn-outline { background: transparent; color: var(--text); border: 1px solid var(--border); }
+        .btn-warn { background: var(--warn); color: #000; }
+        .btns { display: flex; gap: 0.6rem; flex-wrap: wrap; margin-top: 1rem; }
+        .table-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 0.5rem;
+            margin: 0.75rem 0;
+        }
+        .table-item {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 0.4rem;
+            padding: 0.5rem 0.75rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            font-size: 0.82rem;
+            cursor: pointer;
+            transition: border-color 0.15s;
+        }
+        .table-item:hover { border-color: var(--primary); }
+        .table-item.selected { border-color: var(--success); background: #10b98108; }
+        .table-item input { display: none; }
+        .table-name { font-weight: 600; }
+        .table-meta { color: var(--muted); font-size: 0.75rem; }
+        .progress-wrap {
+            background: var(--border);
+            border-radius: 1rem;
+            height: 8px;
+            margin: 0.75rem 0;
+            overflow: hidden;
+        }
+        .progress-bar {
+            height: 100%;
+            background: linear-gradient(90deg, var(--primary), var(--success));
+            border-radius: 1rem;
+            width: 0%;
+            transition: width 0.3s;
+        }
+        .status-text {
+            font-size: 0.82rem;
+            color: var(--muted);
+            margin-bottom: 0.5rem;
+            min-height: 1.2rem;
+        }
+        .result-list { display: flex; flex-direction: column; gap: 0.35rem; margin-top: 0.75rem; }
+        .result-row {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            padding: 0.4rem 0.75rem;
+            background: var(--bg);
+            border-radius: 0.4rem;
+            font-size: 0.82rem;
+        }
+        .tag { font-size: 0.7rem; padding: 0.1rem 0.45rem; border-radius: 0.3rem; }
+        .tag-ok { background: #10b98122; color: var(--success); }
+        .tag-warn { background: #f59e0b22; color: var(--warn); }
+        .tag-err { background: #ef444422; color: var(--danger); }
+        .sql-output {
+            background: #020617;
+            border: 1px solid var(--border);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            font-family: monospace;
+            font-size: 0.73rem;
+            line-height: 1.6;
+            max-height: 400px;
+            overflow: auto;
+            white-space: pre;
+            word-break: break-all;
+            margin-top: 0.75rem;
+            color: #a5f3fc;
+        }
+        .log {
+            background: #020617;
+            border: 1px solid var(--border);
+            border-radius: 0.5rem;
+            padding: 0.75rem;
+            font-family: monospace;
+            font-size: 0.75rem;
+            line-height: 1.7;
+            max-height: 260px;
+            overflow-y: auto;
+            margin-top: 0.75rem;
+        }
+        .l-ok { color: var(--success); }
+        .l-warn { color: var(--warn); }
+        .l-err { color: var(--danger); }
+        .l-info { color: var(--muted); }
+        .l-head { color: #a78bfa; font-weight: bold; }
+        .summary-bar { display: flex; gap: 1rem; flex-wrap: wrap; margin: 0.75rem 0; }
+        .sum-box {
+            background: var(--bg);
+            border-radius: 0.5rem;
+            padding: 0.55rem 1rem;
+            text-align: center;
+            flex: 1;
+            min-width: 80px;
+        }
+        .sum-num { font-size: 1.5rem; font-weight: 700; line-height: 1; }
+        .sum-lbl { font-size: 0.7rem; color: var(--muted); margin-top: 0.1rem; }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 1rem;
+            color: var(--muted);
+            text-decoration: none;
+            font-size: 0.85rem;
+        }
+        .back-link:hover { color: var(--text); }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <a href="admin.html" class="back-link">← 返回管理後台</a>
+        <h1>資料庫匯出工具（→ SQL）</h1>
+        <p class="subtitle">將目前資料庫的所有資料匯出成 <strong>SQL INSERT 語句</strong>，可用於備份或遷移至其他 D1 資料庫。</p>
+
+        <!-- 資料表選擇 -->
+        <div class="card">
+            <div class="card-title">選擇要匯出的資料表</div>
+            <div style="margin-bottom: 0.75rem; display: flex; gap: 0.5rem;">
+                <button class="btn btn-outline" onclick="selectAll(true)">全選</button>
+                <button class="btn btn-outline" onclick="selectAll(false)">全不選</button>
+            </div>
+            <div id="table-grid" class="table-grid"></div>
+        </div>
+
+        <!-- 匯出按鈕 -->
+        <div style="margin-bottom: 1.25rem;">
+            <button id="btn-export" class="btn btn-primary" onclick="startExport()" style="font-size: 1rem; padding: 0.75rem 1.5rem;">掃描並匯出 SQL</button>
+        </div>
+
+        <!-- 進度條 -->
+        <div id="progress-wrap" class="progress-wrap" style="display: none;">
+            <div id="progress-bar" class="progress-bar"></div>
+        </div>
+        <div id="status-text" class="status-text"></div>
+
+        <!-- SQL 輸出區 -->
+        <div id="output-card" class="card" style="display: none;">
+            <div class="card-title">SQL 輸出</div>
+
+            <div class="summary-bar">
+                <div class="sum-box">
+                    <div class="sum-num" id="sum-tables">0</div>
+                    <div class="sum-lbl">資料表</div>
+                </div>
+                <div class="sum-box">
+                    <div class="sum-num" id="sum-rows">0</div>
+                    <div class="sum-lbl">資料筆數</div>
+                </div>
+                <div class="sum-box">
+                    <div class="sum-num" id="sum-size">0</div>
+                    <div class="sum-lbl">大小 (KB)</div>
+                </div>
+                <div class="sum-box">
+                    <div class="sum-num" id="sum-stmts">0</div>
+                    <div class="sum-lbl">SQL 語句數</div>
+                </div>
+            </div>
+
+            <div id="result-list" class="result-list"></div>
+
+            <div class="btns">
+                <button class="btn btn-success" onclick="downloadSQL()">下載完整 .sql</button>
+                <button class="btn btn-primary" onclick="downloadSplit()">拆分下載（建議）</button>
+                <button class="btn btn-outline" onclick="copySQL()">複製</button>
+            </div>
+
+            <div id="split-hint" style="display: none; background: var(--bg); border-radius: 0.5rem; padding: 0.75rem; margin-top: 1rem; font-size: 0.82rem; color: var(--muted);">
+                <strong>拆分下載說明：</strong>因 Cloudflare D1 單次匯入有大小限制，建議使用拆分模式。每個檔案按資料表分開，直接依序匯入即可。
+            </div>
+            <div id="split-file-list" style="display: none; margin-top: 0.75rem;"></div>
+
+            <div style="margin-top: 1rem;">
+                <div style="font-size: 0.85rem; font-weight: 600; margin-bottom: 0.5rem;">SQL 預覽</div>
+                <div id="sql-preview" class="sql-output"></div>
+            </div>
+        </div>
+
+        <!-- 操作日誌 -->
+        <div class="card">
+            <div style="display: flex; gap: 0.5rem; align-items: center; margin-bottom: 0.75rem;">
+                <div class="card-title" style="margin: 0; flex: 1;">操作日誌</div>
+                <button class="btn btn-outline" style="font-size: 0.78rem; padding: 0.4rem 0.8rem;" onclick="clearLog()">清除</button>
+            </div>
+            <div id="log" class="log">等待操作...</div>
+        </div>
+    </div>
+
+    <script>
+        // ══ 全域狀態 ══
+        let TABLE_SCHEMAS = {};
+        let generatedSQL = '';
+        let tableSQLMap = {};
+
+        // ══ 內建 Schema 對照表 ══
+        const FALLBACK_SCHEMAS = {
+            users: ['id','google_id','email','username','nickname','picture','avatar_url','mbti_type','super_liked_games','liked_games','neutral_games','disliked_games','no_interest_games','wishlist','pinned_games','daily_question_count','last_question_date','last_login','bio','social_links'],
+            user_stats: ['id','user_id','xp','level','total_xp','unlocked_badges','daily_quest_completed','last_quest_reset','streak_days','last_login','total_contributions','weekly_contributions','last_weekly_reset'],
+            user_collections: ['id','title','description','games','created_by','creator_name','is_public','play_count','vote_stats','rated_by'],
+            user_collection_votes: ['id','collection_id','voter_id','game_name','vote','voted_at'],
+            game_database: ['id','name_zh','name_ja','name_en','year','min_players','max_players','playing_time','complexity','image_url','description','source','bgg_id','created_at'],
+            game_votes: ['id','user_id','game_name','vote_type','mbti_type','collection_id'],
+            game_aliases: ['id','primary_name','aliases','bgg_id','created_at','updated_at'],
+            game_collections: ['id','title','type','category','games','icon','description','sort_order','is_active','start_date','end_date','questions_per_session'],
+            collection_game_stats: ['id','collection_id','game_name','like_count','wishlist_count'],
+            achievements: ['id','name_zh','name_en','icon','description','rarity','unlock_type','unlock_value','is_limited','created_at'],
+            admin_whitelist: ['id','google_id','email','nickname','picture','role','added_by','added_at','last_access','is_active','notes'],
+            tester_whitelist: ['id','google_id','note','is_active'],
+            influencer_whitelist: ['id','google_id','note','is_active'],
+            publisher_badge_series: ['id','publisher_name','publisher_name_en','icon','image_url','game_list','fan_thresholds','customer_thresholds','is_active','created_by','created_at'],
+            quiz_collections: ['id','title','description','icon','tags','time_limit','is_active','sort_order','created_by','created_at'],
+            quiz_questions: ['id','collection_id','question','options','answer_index','explanation','image_url','time_limit','sort_order','status','submitted_by','created_at'],
+            quiz_attempts: ['id','collection_id','user_id','answers','score','total','time_spent','completed','completed_at'],
+            daily_quests: ['id','title','description','xp_reward','quest_type','requirement','is_active','sort_order'],
+            limited_events: ['id','title','icon','description','start_date','end_date','game_list','rewards','is_active','created_by','created_at'],
+            event_progress: ['id','event_id','user_id','game_id','rating','created_at'],
+            site_stats: ['id','stat_key','stat_value','updated_at'],
+        };
+
+        const TABLE_META = {
+            users: { label: '使用者', icon: '👤' },
+            user_stats: { label: '使用者統計', icon: '📊' },
+            user_collections: { label: '使用者清單', icon: '📚' },
+            user_collection_votes: { label: '清單投票', icon: '🗳️' },
+            game_database: { label: '遊戲資料庫', icon: '🎲' },
+            game_votes: { label: '遊戲投票', icon: '👍' },
+            game_aliases: { label: '遊戲別名', icon: '🏷️' },
+            game_collections: { label: '遊戲合集', icon: '🗂️' },
+            collection_game_stats: { label: '清單人氣', icon: '📈' },
+            achievements: { label: '成就', icon: '🏆' },
+            admin_whitelist: { label: '管理員名單', icon: '🛡️' },
+            tester_whitelist: { label: '測試員名單', icon: '🧪' },
+            influencer_whitelist: { label: '推廣者名單', icon: '📣' },
+            publisher_badge_series: { label: '出版社徽章', icon: '🏅' },
+            quiz_collections: { label: '題目清單', icon: '📝' },
+            quiz_questions: { label: '題目', icon: '❓' },
+            quiz_attempts: { label: '作答紀錄', icon: '📋' },
+            daily_quests: { label: '每日任務', icon: '📅' },
+            limited_events: { label: '限定活動', icon: '🎪' },
+            event_progress: { label: '活動進度', icon: '🎯' },
+            site_stats: { label: '站台統計', icon: '📉' },
+        };
+
+        // ── 日誌 ──
+        function log(msg, type = 'info') {
+            const el = document.getElementById('log');
+            if (el.textContent === '等待操作...') el.innerHTML = '';
+            const cls = { ok:'l-ok', warn:'l-warn', err:'l-err', info:'l-info', head:'l-head' }[type] || 'l-info';
+            const t = new Date().toLocaleTimeString('zh-TW');
+            el.innerHTML += `<div class="${cls}">[${t}] ${msg}</div>`;
+            el.scrollTop = el.scrollHeight;
+        }
+
+        function clearLog() {
+            document.getElementById('log').innerHTML = '等待操作...';
+        }
+
+        function setStatus(msg) {
+            document.getElementById('status-text').textContent = msg;
+        }
+
+        function setProgress(pct) {
+            const w = document.getElementById('progress-wrap');
+            w.style.display = pct >= 0 ? 'block' : 'none';
+            document.getElementById('progress-bar').style.width = Math.max(0, pct) + '%';
+        }
+
+        // ══ JWT 有效性檢查 ══
+        function isJwtValid() {
+            const token = localStorage.getItem('google_id_token');
+            if (!token) return false;
+            try {
+                const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+                // 留 60 秒餘裕
+                return payload.exp && (payload.exp * 1000) > (Date.now() + 60000);
+            } catch { return false; }
+        }
+
+        // ══ 帶 JWT 的 fetch（管理員需要存取受保護的表）══
+        function authFetch(url, options = {}) {
+            const token = localStorage.getItem('google_id_token');
+            if (token) {
+                options.headers = options.headers || {};
+                options.headers['Authorization'] = 'Bearer ' + token;
+            }
+            return fetch(url, options);
+        }
+
+        // ══ 動態讀取所有資料表 schema ══
+        async function loadSchemas() {
+            const grid = document.getElementById('table-grid');
+            grid.innerHTML = '<div style="color:var(--muted);font-size:0.85rem;padding:0.5rem">正在從 API 讀取資料表清單...</div>';
+            document.getElementById('btn-export').disabled = true;
+            log('正在從 API 讀取所有資料表 schema...', 'head');
+
+            const knownTables = Object.keys(TABLE_META);
+            TABLE_SCHEMAS = {};
+            for (const t of knownTables) {
+                try {
+                    const r = await authFetch(`tables/${t}?limit=1`);
+                    if (!r.ok) {
+                        log(` ⚠️ ${t}：HTTP ${r.status}，跳過`, 'warn');
+                        continue;
+                    }
+                    const d = await r.json();
+                    let cols = [];
+                    if (d.schema && d.schema.fields && Array.isArray(d.schema.fields)) {
+                        cols = d.schema.fields.map(f => f.name);
+                    } else if (d.data && d.data.length > 0) {
+                        cols = Object.keys(d.data[0]).filter(k => !['gs_project_id', 'gs_table_name'].includes(k));
+                    }
+                    if (cols.length === 0) {
+                        if (FALLBACK_SCHEMAS[t]) {
+                            cols = FALLBACK_SCHEMAS[t];
+                            log(` ✅ ${t}：使用內建 schema（${cols.length} 個欄位，空表）`, 'ok');
+                        } else {
+                            log(` ⚠️ ${t}：無法取得欄位資訊（空表且無 schema）`, 'warn');
+                            TABLE_SCHEMAS[t] = { cols: ['id'], ...(TABLE_META[t] || { label: t, icon: '📄' }) };
+                            continue;
+                        }
+                    }
+                    cols = cols.filter(c => c !== 'id' && c !== 'deleted');
+                    cols = ['id', ...cols];
+                    TABLE_SCHEMAS[t] = { cols, ...(TABLE_META[t] || { label: t, icon: '📄' }) };
+                    log(` ✅ ${t}：${cols.length} 個欄位`, 'ok');
+                } catch(e) {
+                    log(` ❌ ${t}：${e.message}`, 'err');
+                }
+                await sleep(60);
+            }
+            const found = Object.keys(TABLE_SCHEMAS).length;
+            log(`─── 共載入 ${found} 張資料表 ───`, 'head');
+            renderGrid();
+            document.getElementById('btn-export').disabled = false;
+            setStatus(`已載入 ${found} 張資料表，可開始匯出`);
+        }
+
+        // ── 渲染資料表選擇格 ──
+        function renderGrid() {
+            const grid = document.getElementById('table-grid');
+            const tables = Object.keys(TABLE_SCHEMAS);
+            if (tables.length === 0) {
+                grid.innerHTML = '<div style="color:var(--danger);padding:0.5rem">無法載入任何資料表</div>';
+                return;
+            }
+            grid.innerHTML = tables.map(t => {
+                const s = TABLE_SCHEMAS[t];
+                return `<label class="table-item selected" id="item-${t}">
+                    <input type="checkbox" value="${t}" checked onchange="toggleItem('${t}', this.checked)">
+                    <span class="table-name">${s.icon} ${t}</span>
+                    <span class="table-meta" id="meta-${t}">${s.cols.length} 欄</span>
+                </label>`;
+            }).join('');
+        }
+
+        function toggleItem(t, checked) {
+            document.getElementById('item-' + t)?.classList.toggle('selected', checked);
+        }
+
+        function selectAll(v) {
+            document.querySelectorAll('#table-grid input').forEach(cb => {
+                cb.checked = v;
+                toggleItem(cb.value, v);
+            });
+        }
+
+        function getSelectedTables() {
+            return [...document.querySelectorAll('#table-grid input:checked')].map(i => i.value);
+        }
+
+        // ══ 主流程：掃描 + 匯出 ══
+        async function startExport() {
+            const tables = getSelectedTables();
+            if (tables.length === 0) { alert('請至少選擇一張資料表'); return; }
+
+            const btn = document.getElementById('btn-export');
+            btn.disabled = true;
+            document.getElementById('result-list').innerHTML = '';
+            document.getElementById('output-card').style.display = 'none';
+            generatedSQL = '';
+            tableSQLMap = {};
+            setProgress(0);
+            log('═══════════════════════════', 'head');
+            log('開始掃描並匯出...', 'head');
+
+            const sqlParts = [];
+            const resultRows = [];
+            let totalRows = 0;
+            let totalStmts = 0;
+
+            sqlParts.push('-- ========================================');
+            sqlParts.push('-- 桌遊社群資料庫備份');
+            sqlParts.push(`-- 匯出時間：${new Date().toLocaleString('zh-TW')}`);
+            sqlParts.push(`-- 資料表數：${tables.length}`);
+            sqlParts.push('-- ========================================');
+            sqlParts.push('-- INSERT OR REPLACE 若 id 已存在則整筆覆蓋更新');
+            sqlParts.push('-- ========================================\n');
+
+            for (let i = 0; i < tables.length; i++) {
+                const t = tables[i];
+                const schema = TABLE_SCHEMAS[t];
+                setProgress(Math.round((i / tables.length) * 100));
+                setStatus(`正在處理 ${t}（${i+1}/${tables.length}）...`);
+                log(`抓取 ${schema.icon} ${t}...`, 'info');
+                try {
+                    const rows = await fetchAllRows(t);
+                    totalRows += rows.length;
+                    log(` ✅ ${t}：${rows.length} 筆`, 'ok');
+                    document.getElementById('meta-' + t).textContent = `${rows.length} 筆`;
+
+                    sqlParts.push('-- ──────────────────────────────');
+                    sqlParts.push(`-- 資料表：${t}（${rows.length} 筆，${schema.cols.length} 欄）`);
+                    sqlParts.push('-- ──────────────────────────────');
+
+                    const tablePartLines = [];
+                    tablePartLines.push('-- ========================================');
+                    tablePartLines.push('-- 桌遊社群資料庫備份（拆分檔）');
+                    tablePartLines.push(`-- 資料表：${t}（${rows.length} 筆，${schema.cols.length} 欄）`);
+                    tablePartLines.push(`-- 匯出時間：${new Date().toLocaleString('zh-TW')}`);
+                    tablePartLines.push('-- ========================================');
+                    tablePartLines.push('-- INSERT OR REPLACE 若 id 已存在則整筆覆蓋更新');
+                    tablePartLines.push('-- ========================================');
+                    tablePartLines.push('');
+                    tablePartLines.push('BEGIN TRANSACTION;');
+
+                    if (rows.length > 0) {
+                        const cols = schema.cols;
+                        let stmtsForTable = 0;
+                        for (const row of rows) {
+                            const values = cols.map(col => sqlValue(row[col]));
+                            const stmt = `INSERT OR REPLACE INTO \`${t}\` (${cols.map(c=>'`'+c+'`').join(', ')}) VALUES (${values.join(', ')});`;
+                            tablePartLines.push(stmt);
+                            sqlParts.push(stmt);
+                            stmtsForTable++;
+                            totalStmts++;
+                        }
+                        log(` 📝 生成 ${stmtsForTable} 條 INSERT 語句`, 'info');
+                    } else {
+                        tablePartLines.push('-- （無資料）');
+                        sqlParts.push('-- （無資料）');
+                    }
+                    tablePartLines.push('COMMIT;');
+                    tablePartLines.push('');
+                    tableSQLMap[t] = tablePartLines.join('\n');
+                    sqlParts.push('');
+                    resultRows.push({ table: t, count: rows.length, status: 'ok', icon: schema.icon });
+                } catch(e) {
+                    log(` ❌ ${t} 失敗：${e.message}`, 'err');
+                    resultRows.push({ table: t, count: 0, status: 'err', msg: e.message, icon: schema.icon });
+                    sqlParts.push(`-- ❌ ${t} 匯出失敗：${e.message}\n`);
+                }
+                await sleep(120);
+            }
+
+            generatedSQL = sqlParts.join('\n');
+            const sizeKB = Math.round(generatedSQL.length / 1024);
+            setProgress(100);
+            setTimeout(() => setProgress(-1), 1500);
+            setStatus(`完成！${totalRows.toLocaleString()} 筆資料，${totalStmts.toLocaleString()} 條 SQL，${sizeKB} KB`);
+            log('═══════════════════════════', 'head');
+            log(`完成！總計 ${totalRows} 筆 / ${totalStmts} 條 INSERT / ${sizeKB} KB`, 'head');
+
+            document.getElementById('sum-tables').textContent = tables.length;
+            document.getElementById('sum-rows').textContent = totalRows.toLocaleString();
+            document.getElementById('sum-size').textContent = sizeKB.toLocaleString();
+            document.getElementById('sum-stmts').textContent = totalStmts.toLocaleString();
+
+            const previewLines = generatedSQL.split('\n').slice(0, 100).join('\n');
+            document.getElementById('sql-preview').textContent = previewLines + (generatedSQL.split('\n').length > 100 ? '\n\n...(預覽前 100 行，請下載完整版)' : '');
+
+            document.getElementById('result-list').innerHTML = resultRows.map(r => `<div class="result-row">
+                <span>${r.icon} <strong>${r.table}</strong></span>
+                <span style="color:var(--muted)">${r.count.toLocaleString()} 筆</span>
+                <span class="tag ${r.status === 'ok' ? 'tag-ok' : 'tag-err'}">
+                    ${r.status === 'ok' ? '✅ 完成' : '❌ ' + r.msg}
+                </span>
+            </div>`).join('');
+
+            document.getElementById('output-card').style.display = 'block';
+            document.getElementById('output-card').scrollIntoView({ behavior: 'smooth', block: 'start' });
+            btn.disabled = false;
+        }
+
+        // ══ SQL 值轉換 ══
+        function sqlValue(val) {
+            if (val === null || val === undefined) return 'NULL';
+            if (typeof val === 'boolean') return val ? '1' : '0';
+            if (typeof val === 'number') return isFinite(val) ? String(val) : 'NULL';
+            if (typeof val === 'object') return `'${sqlEscape(JSON.stringify(val))}'`;
+            const s = String(val);
+            if (s === '[object Object]') return `'${sqlEscape(JSON.stringify(val))}'`;
+            return `'${sqlEscape(s)}'`;
+        }
+
+        function sqlEscape(s) {
+            return s.replace(/'/g, "''").replace(/\0/g, '').replace(/\r\n/g, ' ').replace(/\r/g, ' ').replace(/\n/g, ' ');
+        }
+
+        // ══ 分頁抓全部資料 ══
+        async function fetchAllRows(tableName) {
+            const rows = [];
+            let page = 1;
+            const LIMIT = 100;
+            while (true) {
+                const r = await authFetch(`tables/${tableName}?page=${page}&limit=${LIMIT}`);
+                if (!r.ok) throw new Error(`HTTP ${r.status}`);
+                const d = await r.json();
+                const batch = d.data || [];
+                rows.push(...batch);
+                const total = d.total || 0;
+                if (rows.length >= total || batch.length < LIMIT) break;
+                page++;
+                await sleep(80);
+            }
+            return rows;
+        }
+
+        // ══ 拆分下載 ══
+        function downloadSplit() {
+            if (!generatedSQL || Object.keys(tableSQLMap).length === 0) { alert('請先匯出 SQL'); return; }
+            document.getElementById('split-hint').style.display = 'block';
+            const listEl = document.getElementById('split-file-list');
+            const tables = Object.keys(tableSQLMap);
+            const rows = tables.map(t => {
+                const schema = TABLE_SCHEMAS[t];
+                const lines = tableSQLMap[t].split('\n').filter(l => l.startsWith('INSERT')).length;
+                const sizeKB = Math.round(tableSQLMap[t].length / 1024);
+                const fname = `db-${t}-${new Date().toISOString().slice(0,10)}.sql`;
+                return `<div style="display:flex; align-items:center; gap:0.6rem; padding:0.4rem 0.75rem; background:var(--bg); border-radius:0.4rem; font-size:0.82rem; margin-bottom:0.3rem;">
+                    <span>${schema?.icon || '📄'} <strong>${t}</strong></span>
+                    <span style="color:var(--muted);flex:1">${lines} 筆 · ${sizeKB} KB</span>
+                    <button class="btn btn-success" style="padding:0.25rem 0.7rem;font-size:0.78rem" onclick="downloadOneSplit('${t}','${fname}')">下載</button>
+                </div>`;
+            });
+            listEl.innerHTML = `<div style="margin-bottom:0.5rem; display:flex; gap:0.5rem;">
+                <button class="btn btn-warn" onclick="downloadAllSplit()">全部依序下載（${tables.length} 個檔案）</button>
+            </div>${rows.join('')}`;
+            listEl.style.display = 'block';
+            log(`已生成 ${tables.length} 個拆分檔`, 'ok');
+        }
+
+        function downloadOneSplit(tableName, filename) {
+            const sql = tableSQLMap[tableName];
+            if (!sql) { alert('找不到 ' + tableName + ' 的 SQL'); return; }
+            const blob = new Blob([sql], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url; a.download = filename; a.click();
+            URL.revokeObjectURL(url);
+            log(`下載：${filename}`, 'ok');
+        }
+
+        async function downloadAllSplit() {
+            const tables = Object.keys(tableSQLMap);
+            for (let i = 0; i < tables.length; i++) {
+                const t = tables[i];
+                const fname = `db-${String(i+1).padStart(2,'0')}-${t}-${new Date().toISOString().slice(0,10)}.sql`;
+                downloadOneSplit(t, fname);
+                await sleep(600);
+            }
+            log(`全部 ${tables.length} 個檔案下載完畢`, 'ok');
+        }
+
+        function downloadSQL() {
+            if (!generatedSQL) { alert('請先匯出'); return; }
+            const blob = new Blob([generatedSQL], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `boardgame-db-${new Date().toISOString().slice(0,10)}.sql`;
+            a.click();
+            URL.revokeObjectURL(url);
+            log('SQL 檔案已下載', 'ok');
+        }
+
+        async function copySQL() {
+            if (!generatedSQL) { alert('請先匯出'); return; }
+            try {
+                await navigator.clipboard.writeText(generatedSQL);
+                log('已複製到剪貼簿', 'ok');
+                alert('已複製！');
+            } catch(e) {
+                log('複製失敗（請改用下載）', 'err');
+                alert('複製失敗，請使用「下載 .sql 檔案」');
+            }
+        }
+
+        function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+        // ══ 重新取得 Google credential ══
+        function promptTokenRefresh() {
+            log('JWT 已過期，需要重新登入以存取受保護的資料表...', 'warn');
+            setStatus('JWT 已過期，請點擊下方按鈕重新登入');
+
+            const wrap = document.createElement('div');
+            wrap.id = 'token-refresh-bar';
+            wrap.style.cssText = 'background:var(--card);border:1px solid var(--warn);border-radius:0.75rem;padding:1rem 1.5rem;margin-bottom:1.25rem;display:flex;align-items:center;gap:1rem;flex-wrap:wrap;';
+            wrap.innerHTML = `
+                <span style="color:var(--warn);font-size:0.9rem;flex:1">⚠️ Google JWT 已過期，需重新登入才能讀取所有資料表（含使用者、管理員等）</span>
+                <div id="refresh-signin-btn"></div>
+                <button class="btn btn-outline" style="font-size:0.82rem" onclick="skipTokenRefresh()">跳過（僅匯出公開表）</button>
+            `;
+            const container = document.querySelector('.container');
+            const exportBtn = document.getElementById('btn-export').parentElement;
+            container.insertBefore(wrap, exportBtn);
+
+            // 渲染 Google 登入按鈕
+            if (typeof google !== 'undefined' && google.accounts) {
+                google.accounts.id.initialize({
+                    client_id: '105319270176-djqr0n6r4l3mvmpalsqjn8kasqii9ukt.apps.googleusercontent.com',
+                    callback: handleTokenRefresh
+                });
+                google.accounts.id.renderButton(
+                    document.getElementById('refresh-signin-btn'),
+                    { theme: 'filled_blue', size: 'medium', text: 'signin_with' }
+                );
+            }
+        }
+
+        function handleTokenRefresh(response) {
+            localStorage.setItem('google_id_token', response.credential);
+            log('✅ JWT 已刷新', 'ok');
+            setStatus('JWT 已刷新，開始載入資料表...');
+            const bar = document.getElementById('token-refresh-bar');
+            if (bar) bar.remove();
+            loadSchemas();
+        }
+
+        function skipTokenRefresh() {
+            log('跳過 JWT 刷新，僅匯出公開資料表', 'warn');
+            const bar = document.getElementById('token-refresh-bar');
+            if (bar) bar.remove();
+            loadSchemas();
+        }
+
+        // ══ 頁面載入：等待 admin 驗證通過後才開始掃描 ══
+        document.addEventListener('adminAuthenticated', () => {
+            log('管理員驗證通過', 'ok');
+            if (isJwtValid()) {
+                log('JWT 有效，開始載入資料表...', 'ok');
+                loadSchemas();
+            } else {
+                promptTokenRefresh();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/public/js/admin-auth.js
+++ b/public/js/admin-auth.js
@@ -5,9 +5,11 @@
 
 // ========== 配置 ==========
 const ADMIN_AUTH_CONFIG = {
-    // 超級管理員的 Google ID（您的帳號）
-    // 這是寫死在程式碼中的，永遠有權限
-    SUPER_ADMIN_GOOGLE_ID: '101279808163813574015', // 請替換為您的 Google ID
+    // 超級管理員的 Google ID（寫死在程式碼中，永遠有權限）
+    SUPER_ADMIN_IDS: [
+        '101279808163813574015', // 客戶（Emailev01）
+        '103111021786847709012', // 開發者（wake.gs）
+    ],
     
     // 驗證狀態儲存時間（毫秒）- 預設 4 小時
     SESSION_DURATION: 4 * 60 * 60 * 1000,
@@ -53,7 +55,7 @@ async function loadAdminWhitelist() {
 
 async function checkIsAdmin(googleId, email) {
     // 1. 檢查是否為超級管理員（寫死在程式碼中）
-    if (googleId === ADMIN_AUTH_CONFIG.SUPER_ADMIN_GOOGLE_ID) {
+    if (ADMIN_AUTH_CONFIG.SUPER_ADMIN_IDS.includes(googleId)) {
         console.log('✅ 超級管理員驗證通過');
         return { isAdmin: true, role: 'super_admin', source: 'hardcoded' };
     }
@@ -313,11 +315,14 @@ async function handleAdminGoogleLogin(response) {
     try {
         const credential = response.credential;
         const payload = parseJwt(credential);
-        
+
         if (!payload) {
             throw new Error('無法解析 Google 登入資訊');
         }
-        
+
+        // 儲存 JWT credential（供 admin-db-migrate 等頁面的 authFetch 使用）
+        localStorage.setItem('google_id_token', credential);
+
         console.log('Google 登入成功，檢查管理員權限...');
         
         // 檢查是否為管理員


### PR DESCRIPTION
## Summary
- 新增 `admin-db-migrate.html` 資料庫匯出工具（SQL INSERT 格式，支援全表/拆分下載）
- `admin-auth.js`: 管理員登入時儲存 JWT credential，修復 authFetch 無法取得有效 token 的問題
- `admin-auth.js`: SUPER_ADMIN 改為陣列 `SUPER_ADMIN_IDS`，支援多位超級管理員
- `admin-db-migrate.html`: 載入前檢查 JWT 有效性，過期時顯示重新登入提示（可跳過僅匯出公開表）
- `worker.js`: `deleted_at` 偵測改為動態查詢欄位，不再硬編碼排除清單

## Test plan
- [ ] 以管理員帳號登入後開啟 admin-db-migrate.html
- [ ] 確認全部 20 張資料表正常載入
- [ ] JWT 過期時應顯示黃色提示列，重新登入後可載入受保護的表
- [ ] 選擇資料表後點擊「掃描並匯出 SQL」，測試下載與拆分下載功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)