### PR TITLE
Fix missing Authorization headers on API write requests

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -418,7 +418,7 @@
                         // 新使用者 → 建立記錄
                         const createResp = await fetch('tables/users', {
                             method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
+                            headers: getAuthHeaders(),
                             body: JSON.stringify({
                                 google_id: payload.sub,
                                 email: payload.email,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -127,13 +127,26 @@ async function getSiteStats() {
 }
 
 /**
+ * 取得含 JWT Authorization 的 headers（自動從 localStorage 注入）
+ */
+function getAuthHeaders(extra = {}) {
+    const token = localStorage.getItem('google_id_token');
+    const h = { 'Content-Type': 'application/json', ...extra };
+    if (token && !h['Authorization']) h['Authorization'] = 'Bearer ' + token;
+    return h;
+}
+
+/**
  * safePatch(url, patchData)
  * GET 取回現有資料 → 移除所有非 schema 欄位 → PUT 回去
- * 
+ *
  * Genspark/D1 只接受 schema 裡存在的欄位，多送就 500
  * 系統欄位（gs_*、_rid 等）、created_at、updated_at 都不能送
  */
 async function safePatch(url, patchData, headers = {}) {
+    // 自動注入 JWT Authorization header
+    headers = getAuthHeaders(headers);
+
     // 1. 取回現有資料
     const getRes = await fetch(url, { headers });
     if (!getRes.ok) throw new Error(`GET 失敗 HTTP ${getRes.status}`);
@@ -294,7 +307,7 @@ async function createUser(userData) {
     try {
         const response = await fetch(API_BASE, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: getAuthHeaders(),
             body: JSON.stringify(userData)
         });
         if (!response.ok) throw new Error('無法新增使用者');
@@ -555,7 +568,7 @@ async function createUserStats(userId) {
     try {
         const response = await fetch('tables/user_stats', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: getAuthHeaders(),
             body: JSON.stringify({
                 user_id: userId,
                 total_xp: 100, // 註冊獎勵

--- a/public/my-collections.html
+++ b/public/my-collections.html
@@ -745,7 +745,7 @@
                 payload.id = `uc_${currentUser.id.slice(0,8)}_${Date.now()}`;
                 res = await fetch(`tables/${TABLE}`, {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: getAuthHeaders(),
                     body: JSON.stringify(payload)
                 });
             }

--- a/public/player.html
+++ b/public/player.html
@@ -1325,7 +1325,7 @@
             } else {
                 await fetch('tables/game_votes', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: getAuthHeaders(),
                     body: JSON.stringify({
                         id: `gv_${currentUser.id.slice(-6)}_${Date.now()}`,
                         user_id:   currentUser.id,
@@ -1348,7 +1348,7 @@
             const voteId = `ucv_${collectionId.slice(-6)}_${currentUser.id.slice(-6)}_${Date.now()}`;
             await fetch('tables/user_collection_votes', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: getAuthHeaders(),
                 body: JSON.stringify({
                     id: voteId,
                     collection_id: collectionId,

--- a/public/profile.html
+++ b/public/profile.html
@@ -534,6 +534,8 @@
         // ── safePatch 備援定義（若 app.js 尚未載入時使用）──
         if (typeof safePatch === 'undefined') {
             window.safePatch = async function(url, patchData, headers = {}) {
+                const _t = localStorage.getItem('google_id_token');
+                if (_t && !headers['Authorization']) headers = { ...headers, 'Authorization': 'Bearer ' + _t };
                 const sys = ['gs_project_id','gs_table_name','gs_created_at','gs_updated_at',
                              'created_at','updated_at','deleted','deleted_at','_rid','_id','__rid','__id'];
                 const g = await fetch(url, { headers });
@@ -2112,7 +2114,7 @@
                         } else {
                             await fetch('tables/game_votes', {
                                 method: 'POST',
-                                headers: { 'Content-Type': 'application/json' },
+                                headers: typeof getAuthHeaders === 'function' ? getAuthHeaders() : { 'Content-Type': 'application/json' },
                                 body: JSON.stringify({
                                     id: `gv_${currentUser.id.slice(-6)}_${Date.now()}`,
                                     user_id:    currentUser.id,

--- a/public/quiz.html
+++ b/public/quiz.html
@@ -575,7 +575,7 @@
             try {
                 const r = await fetch('tables/quiz_attempts', {
                     method: 'POST',
-                    headers: {'Content-Type':'application/json'},
+                    headers: getAuthHeaders(),
                     body: JSON.stringify({
                         collection_id: colId,
                         user_id: uid,
@@ -956,7 +956,7 @@
         try {
             const r = await fetch('tables/quiz_questions', {
                 method: 'POST',
-                headers: {'Content-Type':'application/json'},
+                headers: getAuthHeaders(),
                 body: JSON.stringify(payload)
             });
             if (!r.ok) throw new Error('送出失敗');

--- a/public/recommend.html
+++ b/public/recommend.html
@@ -1318,7 +1318,7 @@
                 const wishlist_count = rating === 'wishlist' ? 1 : 0;
                 await fetch('tables/collection_game_stats', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: getAuthHeaders(),
                     body: JSON.stringify({ collection_id: collectionId, game_name: gameName, like_count, wishlist_count })
                 });
             } catch(e) {}
@@ -1353,7 +1353,7 @@
                     // 首次建立：直接用新分（舊分扣不到）
                     await fetch('tables/collection_game_stats', {
                         method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
+                        headers: getAuthHeaders(),
                         body: JSON.stringify({
                             collection_id: collectionId,
                             game_name: gameName,
@@ -1483,7 +1483,7 @@
                     // 首次評價：寫入新紀錄
                     await fetch('tables/game_votes', {
                         method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
+                        headers: getAuthHeaders(),
                         body: JSON.stringify({
                             user_id:       currentUser.id,
                             game_name:     gameName,


### PR DESCRIPTION
## Summary
- Add `getAuthHeaders()` helper in `app.js` — auto-injects JWT `Authorization: Bearer` from localStorage
- Fix `safePatch()` to use auth headers (covers all partial-update calls site-wide)
- Fix all direct `fetch()` POST/PUT calls across 6 user-facing pages

Without this fix, all write operations (profile save, votes, collections, quiz) return **401 Authentication required** from the Worker.

## Changed files
- `js/app.js` — new `getAuthHeaders()`, updated `safePatch`, `createUser`, `createUserStats`
- `profile.html` — fallback safePatch + direct POST
- `index.html`, `player.html`, `recommend.html`, `my-collections.html`, `quiz.html` — direct POST calls

## Test plan
- [ ] Save profile bio/social links — should succeed without 401
- [ ] Vote on a game from player page
- [ ] Create a new collection
- [ ] Submit a quiz and quiz question
- [ ] Verify new user registration flow on index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)