### PR TITLE
Allow MBTI change & fix null guard in profile save

### DIFF
--- a/public/profile.html
+++ b/public/profile.html
@@ -292,8 +292,8 @@
                                                      gap: 0.35rem;"
                                               onmouseover="this.style.transform='scale(1.05)'; this.style.boxShadow='0 4px 12px rgba(0,0,0,0.2)'"
                                               onmouseout="this.style.transform='scale(1)'; this.style.boxShadow='none'"
-                                              title="點擊設定 MBTI（設定後無法更改）" 
-                                              id="profile-mbti">INTJ<span id="mbti-lock-icon" style="display:none;font-size:0.75rem;opacity:0.85;">🔒</span>
+                                              title="點擊設定或更改 MBTI"
+                                              id="profile-mbti">INTJ<span id="mbti-lock-icon" style="display:none;font-size:0.75rem;opacity:0.85;"></span>
                                         </span>
                                         <span style="color: var(--text-light);" id="profile-mbti-name">建築師</span>
                                         <span class="level-badge" id="profile-level-badge">Lv. 1</span>
@@ -877,7 +877,7 @@
                 mbtiElement.textContent = '未設定';
                 mbtiElement.onclick = showMBTIPicker;
                 mbtiElement.style.cursor = 'pointer';
-                mbtiElement.title = '點擊設定 MBTI（設定後無法更改）';
+                mbtiElement.title = '點擊設定 MBTI';
             }
             if (mbtiNameElement) mbtiNameElement.textContent = '點擊設定 MBTI';
             
@@ -945,7 +945,7 @@
                 
                 // 檢查使用者的 MBTI 類型
                 console.log('檢查 MBTI 類型:', currentUser.mbti_type);
-                const mbtiInfo = GameMBTI.MBTI_TYPES[currentUser.mbti_type];
+                let mbtiInfo = GameMBTI.MBTI_TYPES[currentUser.mbti_type];
                 
                 if (!mbtiInfo) {
                     console.error('❌ 找不到 MBTI 類型:', currentUser.mbti_type);
@@ -1013,15 +1013,12 @@
                     lockSpan.id = 'mbti-lock-icon';
                     lockSpan.style.cssText = 'font-size:0.75rem;opacity:0.85;';
                     if (currentUser.mbti_type) {
-                        // 已鎖定：移除點擊互動和 hover 效果，顯示鎖頭
-                        lockSpan.textContent = '🔒';
+                        // 已設定但可修改：顯示鉛筆 icon，保留點擊
+                        lockSpan.textContent = '✏️';
                         lockSpan.style.display = 'inline';
-                        mbtiElement.style.cursor = 'default';
-                        mbtiElement.title = 'MBTI 已鎖定（選定後無法自行更改）';
-                        mbtiElement.onmouseover = null;
-                        mbtiElement.onmouseout  = null;
-                        mbtiElement.removeAttribute('onmouseover');
-                        mbtiElement.removeAttribute('onmouseout');
+                        mbtiElement.style.cursor = 'pointer';
+                        mbtiElement.title = '點擊更改 MBTI';
+                        mbtiElement.onclick = showMBTIPicker;
                     } else {
                         lockSpan.style.display = 'none';
                     }
@@ -2252,23 +2249,6 @@
 
         // 🎯 顯示 MBTI 選擇器
         function showMBTIPicker() {
-            // ── 已選定 MBTI 後不允許更改 ──
-            if (currentUser && currentUser.mbti_type) {
-                const overlay = document.createElement('div');
-                overlay.style.cssText = `position:fixed;inset:0;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;z-index:10001;padding:1rem;`;
-                overlay.innerHTML = `
-                    <div style="background:var(--card-bg,white);border-radius:1rem;padding:2rem;max-width:400px;width:100%;text-align:center;box-shadow:0 20px 60px rgba(0,0,0,0.3);">
-                        <div style="font-size:3rem;margin-bottom:1rem;">🔒</div>
-                        <h2 style="margin:0 0 0.75rem;color:var(--text-color);">MBTI 已鎖定</h2>
-                        <p style="color:var(--text-light);margin:0 0 0.5rem;line-height:1.6;">你已選定 <strong style="color:var(--primary-color);font-size:1.1rem;">${currentUser.mbti_type}</strong></p>
-                        <p style="color:var(--text-light);font-size:0.88rem;margin:0 0 1.5rem;line-height:1.6;">為確保資料一致性，MBTI 類型選定後無法自行更改。<br>如需修正請聯繫管理員。</p>
-                        <button onclick="this.closest('[style*=fixed]').remove()" style="padding:0.65rem 2rem;background:var(--primary-color,#667eea);color:white;border:none;border-radius:0.5rem;font-size:1rem;cursor:pointer;">了解</button>
-                    </div>`;
-                overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
-                document.body.appendChild(overlay);
-                return;
-            }
-
             const mbtiTypes = {
                 'INTJ': { name: '建築師', description: '富有想像力和戰略性的思考者' },
                 'INTP': { name: '邏輯學家', description: '具有創新精神的發明家' },
@@ -3666,7 +3646,7 @@
 
                 // 如有選新頭貼，先存 localStorage，並加入 PATCH body
                 if (_bioAvatarPending) {
-                    const userId = currentUser.google_id || currentUser.id;
+                    const userId = currentUser?.google_id || currentUser?.id;
                     localStorage.setItem(`avatar_${userId}`, _bioAvatarPending.url);
                     document.getElementById('profile-avatar').src = _bioAvatarPending.url;
                     patchBody.avatar_url = _bioAvatarPending.url;


### PR DESCRIPTION
## Summary
- 移除 MBTI 鎖定：使用者現在可以自行更改 MBTI 類型（原本設定後就鎖定）
- 鎖頭圖示改為鉛筆圖示，提示可點擊修改
- 修復 `saveBioEditor()` 中 `currentUser` 為 null 時的 `Cannot read properties of null (reading 'google_id')` 錯誤

Fixes #8
Fixes #9

> **注意**：Issue #8 和 #9 的「更新失敗」和「401 認證」問題已在 PR #12 中修復（補上缺失的 Authorization headers）。本 PR 處理 MBTI 開放修改和 null guard。

## Test plan
- [ ] 設定 MBTI（新帳號）— 應正常運作
- [ ] 更改已設定的 MBTI — 現在應允許（原本會顯示🔒鎖定）
- [ ] MBTI 徽章顯示✏️鉛筆而非🔒鎖頭
- [ ] 儲存簡介時 currentUser 為 null — 優雅錯誤而非 crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)