### PR TITLE
修復個人檔案儲存時 currentUser 為 null 的崩潰問題

### DIFF
--- a/public/profile.html
+++ b/public/profile.html
@@ -945,7 +945,7 @@
                 
                 // 檢查使用者的 MBTI 類型
                 console.log('檢查 MBTI 類型:', currentUser.mbti_type);
-                const mbtiInfo = GameMBTI.MBTI_TYPES[currentUser.mbti_type];
+                let mbtiInfo = GameMBTI.MBTI_TYPES[currentUser.mbti_type];
                 
                 if (!mbtiInfo) {
                     console.error('❌ 找不到 MBTI 類型:', currentUser.mbti_type);
@@ -3666,7 +3666,7 @@
 
                 // 如有選新頭貼，先存 localStorage，並加入 PATCH body
                 if (_bioAvatarPending) {
-                    const userId = currentUser.google_id || currentUser.id;
+                    const userId = currentUser?.google_id || currentUser?.id;
                     localStorage.setItem(`avatar_${userId}`, _bioAvatarPending.url);
                     document.getElementById('profile-avatar').src = _bioAvatarPending.url;
                     patchBody.avatar_url = _bioAvatarPending.url;


### PR DESCRIPTION
## 摘要
- 修復 `saveBioEditor()` 中 `currentUser` 為 null 時存取 `google_id` 造成的 `Cannot read properties of null` 錯誤

> **注意**：儲存失敗的 401 錯誤已在 PR #12 中修復

## 測試計畫
- [ ] 儲存簡介（含頭貼變更）— 不再因 null 而崩潰

🤖 Generated with [Claude Code](https://claude.com/claude-code)