### PR TITLE
開放 MBTI 修改 + app.js 快取清除

### DIFF
--- a/public/admin-add-games.html
+++ b/public/admin-add-games.html
@@ -448,7 +448,7 @@
         </div>
     </div>
 
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script>
     // ── 全域狀態 ──
     let fetchedGames = [];   // [{bggId, status, data, selected, rowId}, ...]

--- a/public/admin-admins.html
+++ b/public/admin-admins.html
@@ -12,7 +12,7 @@
     
     <!-- 管理後台驗證 -->
     <script src="js/admin-auth.js?v=20240222-fix"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/show-admin-link.js?v=20240222-fix"></script>
     <script src="js/admin-navbar-cleanup.js"></script>
     <style>

--- a/public/admin-badges.html
+++ b/public/admin-badges.html
@@ -718,7 +718,7 @@
     <!-- 新增按鈕 -->
     <button class="add-badge-btn" id="add-badge-fab" onclick="openModal()" title="新增徽章">+</button>
 
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/show-admin-link.js?v=20240222-fix"></script>
     <script src="js/admin-navbar-cleanup.js"></script>
     <script>

--- a/public/admin-collections.html
+++ b/public/admin-collections.html
@@ -347,7 +347,7 @@
     
     <!-- 管理後台驗證 -->
     <script src="js/admin-auth.js?v=20240222-fix"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     <script src="js/show-admin-link.js?v=20240222-fix"></script>
     <script src="js/admin-navbar-cleanup.js"></script>

--- a/public/admin-db-migrate.html
+++ b/public/admin-db-migrate.html
@@ -10,7 +10,7 @@
 
     <!-- 管理後台驗證 -->
     <script src="js/admin-auth.js?v=20240222-fix"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/show-admin-link.js?v=20240222-fix"></script>
     <script src="js/admin-navbar-cleanup.js"></script>
 

--- a/public/admin-games.html
+++ b/public/admin-games.html
@@ -519,7 +519,7 @@
 
     <!-- 🧹 後台導覽列清理（必須最先載入） -->
     <script src="js/admin-navbar-cleanup.js"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/show-admin-link.js"></script>
     <script>
         // ══ 分頁狀態 ══

--- a/public/admin-quiz.html
+++ b/public/admin-quiz.html
@@ -275,7 +275,7 @@
         </div>
     </div>
 
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/show-admin-link.js?v=20240222-fix"></script>
     <script src="js/admin-navbar-cleanup.js"></script>
     <script>

--- a/public/collection-poster.html
+++ b/public/collection-poster.html
@@ -468,7 +468,7 @@
     </div>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     <script>
     // ── 全域狀態 ──

--- a/public/edit-games-drag.html
+++ b/public/edit-games-drag.html
@@ -565,7 +565,7 @@
     </div>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     <script>
         if (typeof safePatch === 'undefined') { window.safePatch = async function(url, d, h={}) { const sys=['gs_project_id','gs_table_name','gs_created_at','gs_updated_at','created_at','updated_at','deleted','deleted_at','_rid','_id','__rid','__id']; const g=await fetch(url,{headers:h}); const ex=g.ok?await g.json():{}; const cleaned=Object.fromEntries(Object.entries(ex).filter(([k])=>!sys.includes(k))); const merged={...cleaned,...d}; const s={}; for(const [k,v] of Object.entries(merged)){s[k]=(v!==null&&v!==undefined&&typeof v==='object')?JSON.stringify(v):v;} const r=await fetch(url,{method:'PUT',headers:{'Content-Type':'application/json',...h},body:JSON.stringify(s)}); if(!r.ok){const t=await r.text().catch(()=>'');throw new Error('PUT '+r.status+': '+t.slice(0,100));} return r.json(); }; }

--- a/public/edit-games.html
+++ b/public/edit-games.html
@@ -166,7 +166,7 @@
         <p>© 2025 MBTI × 桌遊配對</p>
     </footer>
 
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script>
         let currentUser = null;
         let likedGames = [];

--- a/public/explore-list.html
+++ b/public/explore-list.html
@@ -277,7 +277,7 @@
     </div>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     <script>
         if (typeof safePatch === 'undefined') { window.safePatch = async function(url, d, h={}) { const sys=['gs_project_id','gs_table_name','gs_created_at','gs_updated_at','created_at','updated_at','deleted','deleted_at','_rid','_id','__rid','__id']; const g=await fetch(url,{headers:h}); const ex=g.ok?await g.json():{}; const cleaned=Object.fromEntries(Object.entries(ex).filter(([k])=>!sys.includes(k))); const merged={...cleaned,...d}; const s={}; for(const [k,v] of Object.entries(merged)){s[k]=(v!==null&&v!==undefined&&typeof v==='object')?JSON.stringify(v):v;} const r=await fetch(url,{method:'PUT',headers:{'Content-Type':'application/json',...h},body:JSON.stringify(s)}); if(!r.ok){const t=await r.text().catch(()=>'');throw new Error('PUT '+r.status+': '+t.slice(0,100));} return r.json(); }; }

--- a/public/explore.html
+++ b/public/explore.html
@@ -187,7 +187,7 @@
     </footer>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
 
     <script>

--- a/public/game-picker.html
+++ b/public/game-picker.html
@@ -384,7 +384,7 @@
     </div>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     <script src="js/show-admin-link.js?v=20260223b"></script>
     <script>

--- a/public/games-list.html
+++ b/public/games-list.html
@@ -154,7 +154,7 @@
     </footer>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
 
     <script>

--- a/public/index.html
+++ b/public/index.html
@@ -175,7 +175,7 @@
     </footer>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     
     <!-- safePatch 備援定義 -->

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -94,7 +94,7 @@
     </footer>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
 
     <script>
         let currentUser = null;

--- a/public/my-collections.html
+++ b/public/my-collections.html
@@ -386,7 +386,7 @@
     </div>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     <script>
         if (typeof safePatch === 'undefined') { window.safePatch = async function(url, d, h={}) { const sys=['gs_project_id','gs_table_name','gs_created_at','gs_updated_at','created_at','updated_at','deleted','deleted_at','_rid','_id','__rid','__id']; const g=await fetch(url,{headers:h}); const ex=g.ok?await g.json():{}; const cleaned=Object.fromEntries(Object.entries(ex).filter(([k])=>!sys.includes(k))); const merged={...cleaned,...d}; const s={}; for(const [k,v] of Object.entries(merged)){s[k]=(v!==null&&v!==undefined&&typeof v==='object')?JSON.stringify(v):v;} const r=await fetch(url,{method:'PUT',headers:{'Content-Type':'application/json',...h},body:JSON.stringify(s)}); if(!r.ok){const t=await r.text().catch(()=>'');throw new Error('PUT '+r.status+': '+t.slice(0,100));} return r.json(); }; }

--- a/public/player.html
+++ b/public/player.html
@@ -518,7 +518,7 @@
     </div>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     <script>
         if (typeof safePatch === 'undefined') {

--- a/public/profile.html
+++ b/public/profile.html
@@ -292,8 +292,8 @@
                                                      gap: 0.35rem;"
                                               onmouseover="this.style.transform='scale(1.05)'; this.style.boxShadow='0 4px 12px rgba(0,0,0,0.2)'"
                                               onmouseout="this.style.transform='scale(1)'; this.style.boxShadow='none'"
-                                              title="點擊設定 MBTI（設定後無法更改）" 
-                                              id="profile-mbti">INTJ<span id="mbti-lock-icon" style="display:none;font-size:0.75rem;opacity:0.85;">🔒</span>
+                                              title="點擊設定或更改 MBTI"
+                                              id="profile-mbti">INTJ<span id="mbti-lock-icon" style="display:none;font-size:0.75rem;opacity:0.85;"></span>
                                         </span>
                                         <span style="color: var(--text-light);" id="profile-mbti-name">建築師</span>
                                         <span class="level-badge" id="profile-level-badge">Lv. 1</span>
@@ -527,7 +527,7 @@
     </footer>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
 
     <script>
@@ -879,7 +879,7 @@
                 mbtiElement.textContent = '未設定';
                 mbtiElement.onclick = showMBTIPicker;
                 mbtiElement.style.cursor = 'pointer';
-                mbtiElement.title = '點擊設定 MBTI（設定後無法更改）';
+                mbtiElement.title = '點擊設定 MBTI';
             }
             if (mbtiNameElement) mbtiNameElement.textContent = '點擊設定 MBTI';
             
@@ -1015,15 +1015,12 @@
                     lockSpan.id = 'mbti-lock-icon';
                     lockSpan.style.cssText = 'font-size:0.75rem;opacity:0.85;';
                     if (currentUser.mbti_type) {
-                        // 已鎖定：移除點擊互動和 hover 效果，顯示鎖頭
-                        lockSpan.textContent = '🔒';
+                        // 已設定但可修改：顯示鉛筆 icon，保留點擊
+                        lockSpan.textContent = '✏️';
                         lockSpan.style.display = 'inline';
-                        mbtiElement.style.cursor = 'default';
-                        mbtiElement.title = 'MBTI 已鎖定（選定後無法自行更改）';
-                        mbtiElement.onmouseover = null;
-                        mbtiElement.onmouseout  = null;
-                        mbtiElement.removeAttribute('onmouseover');
-                        mbtiElement.removeAttribute('onmouseout');
+                        mbtiElement.style.cursor = 'pointer';
+                        mbtiElement.title = '點擊更改 MBTI';
+                        mbtiElement.onclick = showMBTIPicker;
                     } else {
                         lockSpan.style.display = 'none';
                     }
@@ -2254,23 +2251,6 @@
 
         // 🎯 顯示 MBTI 選擇器
         function showMBTIPicker() {
-            // ── 已選定 MBTI 後不允許更改 ──
-            if (currentUser && currentUser.mbti_type) {
-                const overlay = document.createElement('div');
-                overlay.style.cssText = `position:fixed;inset:0;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;z-index:10001;padding:1rem;`;
-                overlay.innerHTML = `
-                    <div style="background:var(--card-bg,white);border-radius:1rem;padding:2rem;max-width:400px;width:100%;text-align:center;box-shadow:0 20px 60px rgba(0,0,0,0.3);">
-                        <div style="font-size:3rem;margin-bottom:1rem;">🔒</div>
-                        <h2 style="margin:0 0 0.75rem;color:var(--text-color);">MBTI 已鎖定</h2>
-                        <p style="color:var(--text-light);margin:0 0 0.5rem;line-height:1.6;">你已選定 <strong style="color:var(--primary-color);font-size:1.1rem;">${currentUser.mbti_type}</strong></p>
-                        <p style="color:var(--text-light);font-size:0.88rem;margin:0 0 1.5rem;line-height:1.6;">為確保資料一致性，MBTI 類型選定後無法自行更改。<br>如需修正請聯繫管理員。</p>
-                        <button onclick="this.closest('[style*=fixed]').remove()" style="padding:0.65rem 2rem;background:var(--primary-color,#667eea);color:white;border:none;border-radius:0.5rem;font-size:1rem;cursor:pointer;">了解</button>
-                    </div>`;
-                overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
-                document.body.appendChild(overlay);
-                return;
-            }
-
             const mbtiTypes = {
                 'INTJ': { name: '建築師', description: '富有想像力和戰略性的思考者' },
                 'INTP': { name: '邏輯學家', description: '具有創新精神的發明家' },
@@ -2324,7 +2304,7 @@
             picker.innerHTML = `
                 <h2 style="margin-bottom: 1rem; color: var(--text-color); font-size: 1.5rem;">🎯 選擇你的 MBTI 類型</h2>
                 <div style="background:#fff3cd;border:1px solid #ffc107;border-radius:0.6rem;padding:0.75rem 1rem;margin-bottom:1rem;font-size:0.88rem;color:#856404;">
-                    ⚠️ <strong>選定後無法自行更改</strong>，請先確認你的 MBTI 類型再送出。<br>
+                    💡 請選擇你的 MBTI 類型，之後仍可隨時更改。<br>
                     <span style="font-size:0.82rem;">還不確定？<a href="https://www.16personalities.com/tw" target="_blank" style="color:#856404;font-weight:600;">點此測驗 →</a></span>
                 </div>
                 <div id="mbti-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">

--- a/public/quiz.html
+++ b/public/quiz.html
@@ -407,7 +407,7 @@
     </div>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/admin-navbar-cleanup.js"></script>
     <script>
         if (typeof safePatch === 'undefined') { window.safePatch = async function(url, d, h={}) { const sys=['gs_project_id','gs_table_name','gs_created_at','gs_updated_at','created_at','updated_at','deleted','deleted_at','_rid','_id','__rid','__id']; const g=await fetch(url,{headers:h}); const ex=g.ok?await g.json():{}; const cleaned=Object.fromEntries(Object.entries(ex).filter(([k])=>!sys.includes(k))); const merged={...cleaned,...d}; const s={}; for(const [k,v] of Object.entries(merged)){s[k]=(v!==null&&v!==undefined&&typeof v==='object')?JSON.stringify(v):v;} const r=await fetch(url,{method:'PUT',headers:{'Content-Type':'application/json',...h},body:JSON.stringify(s)}); if(!r.ok){const t=await r.text().catch(()=>'');throw new Error('PUT '+r.status+': '+t.slice(0,100));} return r.json(); }; }

--- a/public/recommend.html
+++ b/public/recommend.html
@@ -537,7 +537,7 @@
     <!-- JavaScript -->
     <script src="js/gamification.js"></script>
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
     <script src="js/game-names.js"></script>
     <script>
         // ── safePatch 備援定義 ──

--- a/public/submit.html
+++ b/public/submit.html
@@ -227,7 +227,7 @@
     </footer>
 
     <script src="js/api-base.js?v=20260302-clear"></script>
-    <script src="js/app.js"></script>
+    <script src="js/app.js?v=20260311"></script>
 
     <script>
         // 檢查登入狀態


### PR DESCRIPTION
## 摘要
- 開放使用者自行更改 MBTI 類型（移除鎖定機制與鎖頭彈窗）
- 鎖頭 🔒 圖示改為鉛筆 ✏️ 圖示，提示可點擊修改
- 選擇器提示文字更新為「💡 請選擇你的 MBTI 類型，之後仍可隨時更改」
- 全站 22 個 HTML 頁面為 `app.js` 加上 `?v=20260311` 版本參數，確保瀏覽器載入最新版本

## 變更檔案
- `profile.html` — MBTI 開放修改（移除鎖定邏輯 + 提示文字）
- 22 個 HTML — `js/app.js` → `js/app.js?v=20260311`

## 測試計畫
- [x] 已設定 MBTI 的帳號 — 點擊 MBTI 徽章應開啟選擇器（原本顯示🔒鎖定彈窗）
- [x] 更改 MBTI 後重新整理 — 應顯示新的 MBTI 類型
- [x] 確認各頁面載入的 app.js 為最新版本（含 `getAuthHeaders`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)