### PR TITLE
修正探索完成後清單不會自動關閉 (#19)

### DIFF
--- a/public/recommend.html
+++ b/public/recommend.html
@@ -1167,12 +1167,14 @@
                 // 全部完成：重置重評模式，重新渲染該清單
                 const wasReRate = isReRateMode;
                 isReRateMode = false;
-                const permanentCollections = gameCollections.filter(c => c.type === 'permanent');
-                const limitedCollections   = gameCollections.filter(c => c.type === 'limited');
-                const publisherCollections = gameCollections.filter(c => isPublisherType(c));
+                const publisherCollections = gameCollections.filter(isPublisherType);
+                const yearlyCollections    = gameCollections.filter(c => !isPublisherType(c) && c.type === 'yearly');
+                const permanentCollections = gameCollections.filter(c => !isPublisherType(c) && c.type === 'permanent');
+                const limitedCollections   = gameCollections.filter(c => !isPublisherType(c) && c.type === 'limited');
+                renderCollections(publisherCollections, 'publisher-collections-container', 'publisher');
+                renderCollections(yearlyCollections,    'yearly-collections-container');
                 renderCollections(permanentCollections, 'permanent-collections-container');
                 renderCollections(limitedCollections,   'limited-collections-container');
-                renderCollections(publisherCollections, 'publisher-collections-container', 'publisher');
                 if (wasReRate) {
                     showNotification('✅ 重評完成！', '已更新你的評分，排名將反映最新喜好 🎯', '🔄');
                 } else {


### PR DESCRIPTION
## Summary
- 修正 `showNextGame` 完成探索後的重新渲染邏輯，補上遺漏的 `yearly` 類型清單
- 統一 `permanent`/`limited` 過濾條件排除 publisher，與初始渲染邏輯一致

## Root Cause
完成探索時的 `renderCollections` 呼叫只處理 3 種類型（permanent, limited, publisher），遺漏了 `yearly`（年度排行），導致該類型清單的遊戲卡片在評價完成後不會被清除。

Closes #19