### PR TITLE
fix: 隨機推薦快取與封面、user_preference_profiles migration

### DIFF
--- a/cloudflare/migrations/README.md
+++ b/cloudflare/migrations/README.md
@@ -1,5 +1,26 @@
 # D1 Migrations
 
+## add_user_preference_profiles.sql
+
+建立 `user_preference_profiles` 表，供「桌友適性」→ 桌遊偏好測驗結果儲存。  
+若未建立，點「儲存到我的檔案」會出現 **Table "user_preference_profiles" not found**。
+
+### 方式一：Cloudflare 主控台
+
+1. 登入 [Cloudflare Dashboard](https://dash.cloudflare.com)
+2. **Workers & Pages** → **D1** → 選你的 D1 資料庫（例如 boardgame-match-db）
+3. 分頁選 **Console**
+4. 貼上 `migrations/add_user_preference_profiles.sql` 內容，按 **Run**
+
+### 方式二：本機 wrangler（遠端 DB）
+
+```bash
+cd cloudflare
+npx wrangler d1 execute boardgame-match-db --remote --file=./migrations/add_user_preference_profiles.sql
+```
+
+---
+
 ## remove_xp_level.sql
 
 移除 `user_stats` 的 `xp`、`level`、`total_xp` 三欄，減輕儲存空間。  

--- a/cloudflare/migrations/add_user_preference_profiles.sql
+++ b/cloudflare/migrations/add_user_preference_profiles.sql
@@ -1,0 +1,15 @@
+-- 桌友適性「桌遊偏好」測驗結果儲存用
+-- 若生產環境 D1 尚未建立此表，會出現 Table "user_preference_profiles" not found，需執行本 migration
+
+CREATE TABLE IF NOT EXISTS user_preference_profiles (
+  user_id TEXT PRIMARY KEY,
+  conflict INTEGER DEFAULT 0,
+  strategy INTEGER DEFAULT 0,
+  social_fun INTEGER DEFAULT 0,
+  immersion INTEGER DEFAULT 0,
+  accessibility INTEGER DEFAULT 0,
+  manipulation INTEGER DEFAULT 0,
+  coop INTEGER DEFAULT 0,
+  luck INTEGER DEFAULT 0,
+  updated_at INTEGER DEFAULT (strftime('%s','now') * 1000)
+);

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -289,7 +289,9 @@ export default {
           const parsedRows = rows.map(row => parseJsonFields(row));
           const countResult = await db.prepare(`SELECT COUNT(*) as total FROM ${tableName}${whereBase}`).first();
           const total = countResult?.total || 0;
-          return jsonResponse({ data: parsedRows, total, table: tableName }, 200, origin, env);
+          const headers = corsHeaders(origin, env);
+          headers['Cache-Control'] = 'no-store';
+          return new Response(JSON.stringify({ data: parsedRows, total, table: tableName }), { status: 200, headers });
         }
 
         const page = parseInt(url.searchParams.get('page') || '1');

--- a/public/recommend.html
+++ b/public/recommend.html
@@ -709,13 +709,17 @@
                 return a;
             }
 
-            // 純隨機做法一：後端支援 ?random=10 時一次請求取 10 筆（Worker 用 seq 或 ORDER BY RANDOM()）
+            // 純隨機做法一：後端支援 ?random=10 時一次請求取 10 筆（Worker 用 ORDER BY RANDOM()）
             async function fetchTenRandomOneRequest() {
-                const res = await fetch('tables/game_database?random=' + RANDOM_RESULT_COUNT);
+                const cacheBuster = '_=' + Date.now();
+                const res = await fetch('tables/game_database?random=' + RANDOM_RESULT_COUNT + '&' + cacheBuster);
                 if (!res.ok) return null;
                 const data = await res.json();
                 const list = (data.data != null ? data.data : Array.isArray(data) ? data : []).filter(g => g && (g.name_zh || g.name_en));
-                return list.length >= RANDOM_RESULT_COUNT ? list.slice(0, RANDOM_RESULT_COUNT) : null;
+                if (list.length < RANDOM_RESULT_COUNT) return null;
+                const games = list.slice(0, RANDOM_RESULT_COUNT);
+                mergeGamesIntoLocalMap(games);
+                return games;
             }
             // 純隨機 fallback：十次「隨機一頁 → 該頁隨機一款」（後端尚未支援 ?random=10 時）
             async function fetchTenRandomFromAllPages() {
@@ -784,8 +788,10 @@
 
             async function runRandom() {
                 const one = await fetchTenRandomOneRequest();
-                const games = one || await fetchTenRandomFromAllPages();
-                return (games || []).slice(0, RANDOM_RESULT_COUNT).map(g => ({ game: g, scoreLabel: null }));
+                let games = one || await fetchTenRandomFromAllPages();
+                games = (games || []).slice(0, RANDOM_RESULT_COUNT);
+                if (games.length) mergeGamesIntoLocalMap(games);
+                return games.map(g => ({ game: g, scoreLabel: null }));
             }
             // 是否為「已評價」：超喜歡、喜歡、普普、不喜歡（不含想玩、沒興趣、跳過）
             function isRatedGameName(name) {
@@ -1040,6 +1046,27 @@
         let _localGameMap = {}; // { normalizedName: { name_zh, name_en, name_ja, image_url } }
 
         function _normName(n) { return n ? n.trim().toLowerCase() : ''; }
+
+        function _gameDisplayName(g) {
+            if (!g) return '';
+            return (g.name_zh || g.name_en || g.name_ja || '').trim();
+        }
+        function mergeGamesIntoLocalMap(games) {
+            if (!Array.isArray(games)) return;
+            games.forEach(g => {
+                const name = _gameDisplayName(g);
+                if (!name) return;
+                const key = _normName(name);
+                const existing = _localGameMap[key];
+                const image_url = (g.image_url && g.image_url.startsWith('http')) ? g.image_url : (existing && existing.image_url) || '';
+                _localGameMap[key] = {
+                    name_zh: g.name_zh || '',
+                    name_en: g.name_en || '',
+                    name_ja: g.name_ja || '',
+                    image_url: image_url
+                };
+            });
+        }
 
         // BGG 預設佔位圖（無實際封面時 BGG 回傳的通用圖片）
         const BGG_PLACEHOLDER = 'pic1657689';


### PR DESCRIPTION
- 隨機：請求加 cache-buster (?random=10&_=ts)，Worker 回傳加 Cache-Control: no-store，避免每次都同一批
- 隨機：10 筆結果 merge 進 _localGameMap，封面優先用 API 回傳 image_url
- 新增 migration add_user_preference_profiles.sql + README 說明，供生產 D1 建立桌遊偏好表

Made-with: Cursor