### PR TITLE
feat: 大頭貼存 R2、D1 只存 URL，上傳限制 3MB

### DIFF
--- a/cloudflare/entry-worker.js
+++ b/cloudflare/entry-worker.js
@@ -13,8 +13,8 @@ export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
-    // 1. /tables/ → 轉發到 D1 API Worker
-    if (url.pathname.startsWith('/tables/')) {
+    // 1. /tables/、/api/、/avatars/ → 轉發到 D1 API Worker（含 R2 大頭貼）
+    if (url.pathname.startsWith('/tables/') || url.pathname.startsWith('/api/') || url.pathname.startsWith('/avatars/')) {
       const apiUrl = new URL(
         'https://mbti-boardgame-api.emailev01.workers.dev' +
           url.pathname +

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -248,6 +248,70 @@ export default {
       }
     }
 
+    // ── 大頭貼上傳（POST /api/upload-avatar）：需 JWT，body { image: "data:image/jpeg;base64,..." }，寫入 R2，回傳公開 URL ──
+    if (url.pathname === '/api/upload-avatar' && method === 'POST') {
+      const authHeader = request.headers.get('Authorization') || '';
+      const token = authHeader.replace(/^Bearer\s+/i, '');
+      if (!token) return errorResponse('Authentication required', 401, origin, env);
+      let jwtPayload;
+      try {
+        jwtPayload = await verifyGoogleJWT(token, env.GOOGLE_CLIENT_ID);
+      } catch (err) {
+        return errorResponse('Authentication failed: ' + err.message, 401, origin, env);
+      }
+      const bucket = env.AVATAR_BUCKET;
+      if (!bucket) return errorResponse('Avatar storage not configured', 503, origin, env);
+      try {
+        const body = await request.json();
+        const dataUrl = body && body.image;
+        if (!dataUrl || typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image/')) {
+          return errorResponse('Body must be { image: "data:image/..." }', 400, origin, env);
+        }
+        const base64Match = dataUrl.match(/^data:image\/\w+;base64,(.+)$/);
+        if (!base64Match) return errorResponse('Invalid data URL', 400, origin, env);
+        const binary = Uint8Array.from(atob(base64Match[1]), c => c.charCodeAt(0));
+        const MAX_AVATAR_BYTES = 3 * 1024 * 1024; // 3MB
+        if (binary.length > MAX_AVATAR_BYTES) {
+          return errorResponse('頭貼不得超過 3MB', 413, origin, env);
+        }
+        const key = `avatars/${jwtPayload.sub}.jpg`;
+        await bucket.put(key, binary, {
+          httpMetadata: { contentType: 'image/jpeg' },
+          customMetadata: { uploaded: String(Date.now()) },
+        });
+        const base = (env.AVATAR_PUBLIC_BASE || '').replace(/\/$/, '') || url.origin;
+        const avatarUrl = `${base}/avatars/${jwtPayload.sub}`;
+        return jsonResponse({ url: avatarUrl }, 200, origin, env);
+      } catch (e) {
+        if (e && (e.status === 400 || e.status === 401)) throw e;
+        console.error('upload-avatar', e);
+        return errorResponse('Upload failed: ' + (e && e.message ? e.message : 'unknown'), 500, origin, env);
+      }
+    }
+
+    // ── 大頭貼讀取（GET /avatars/:userId）：公開，從 R2 回傳圖片，其他玩家可載入 ──
+    const avatarPathMatch = url.pathname.match(/^\/avatars\/([^\/]+)$/);
+    if (avatarPathMatch && method === 'GET') {
+      const userId = avatarPathMatch[1];
+      const bucket = env.AVATAR_BUCKET;
+      if (!bucket) return errorResponse('Avatar storage not configured', 503, origin, env);
+      try {
+        const key = `avatars/${userId}.jpg`;
+        const object = await bucket.get(key);
+        if (!object) {
+          const headers = corsHeaders(origin, env);
+          Object.keys(headers).forEach(k => headers[k] === undefined && delete headers[k]);
+          return new Response(null, { status: 404, headers });
+        }
+        const headers = { ...corsHeaders(origin, env), 'Content-Type': object.httpMetadata?.contentType || 'image/jpeg', 'Cache-Control': 'public, max-age=86400' };
+        Object.keys(headers).forEach(k => headers[k] === undefined && delete headers[k]);
+        return new Response(object.body, { status: 200, headers });
+      } catch (e) {
+        console.error('get-avatar', e);
+        return errorResponse('Avatar not found', 404, origin, env);
+      }
+    }
+
     // 解析路徑：/tables/{table} 或 /tables/{table}/{id}
     const pathMatch = url.pathname.match(/^\/tables\/([^\/]+)\/?([^\/]*)$/);
     if (!pathMatch) {

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -11,7 +11,14 @@ binding = "DB"
 database_name = "boardgame-match-db"
 database_id = "f3387dc6-6fcb-4882-9a84-ddc4a40e6599"
 
+# 大頭貼圖片存 R2，D1 只存 URL（需先建立 bucket：npx wrangler r2 bucket create boardgamematch-avatars）
+[[r2_buckets]]
+binding = "AVATAR_BUCKET"
+bucket_name = "boardgamematch-avatars"
+
 [vars]
 GOOGLE_CLIENT_ID = "105319270176-djqr0n6r4l3mvmpalsqjn8kasqii9ukt.apps.googleusercontent.com"
 ALLOWED_ORIGINS = "https://boardgamematch.com.tw"
+# 大頭貼公開網址前綴（其他玩家用此 URL 讀圖）
+AVATAR_PUBLIC_BASE = "https://boardgamematch.com.tw"
 # API_SECRET 請透過 Cloudflare Dashboard Secrets 或 `wrangler secret put API_SECRET` 設定，勿寫在此檔

--- a/docs/R2-avatar-setup.md
+++ b/docs/R2-avatar-setup.md
@@ -1,0 +1,58 @@
+# R2 大頭貼設定教學
+
+大頭貼改為**圖片存 R2、D1 只存網址**，其他玩家用公開 URL 就能看到頭貼。
+
+---
+
+## 1. 建立 R2 Bucket（只需做一次）
+
+在專案目錄執行：
+
+```bash
+cd cloudflare
+npx wrangler r2 bucket create boardgamematch-avatars
+```
+
+或在 [Cloudflare Dashboard](https://dash.cloudflare.com) → **R2** → **Create bucket**，名稱填 `boardgamematch-avatars`。
+
+---
+
+## 2. 已改動的檔案
+
+| 檔案 | 改動 |
+|------|------|
+| `cloudflare/wrangler.toml` | 新增 R2 綁定 `AVATAR_BUCKET`、變數 `AVATAR_PUBLIC_BASE` |
+| `cloudflare/worker.js` | 新增 `POST /api/upload-avatar`（需 JWT）、`GET /avatars/:userId`（公開） |
+| `cloudflare/entry-worker.js` | `/api/*`、`/avatars/*` 轉發到 API Worker |
+| `public/profile.html` | 上傳頭貼時先呼叫 `/api/upload-avatar`，再將回傳的 URL 寫入 D1 |
+
+---
+
+## 3. 流程說明
+
+1. **上傳**：使用者在個人頁上傳/裁切頭貼 → 前端送 `POST /api/upload-avatar`，body `{ image: "data:image/jpeg;base64,..." }`，帶 `Authorization: Bearer <JWT>`。
+2. **Worker**：驗證 JWT，用 `sub`（Google ID）當檔名，寫入 R2 `avatars/{sub}.jpg`，回傳 `{ url: "https://boardgamematch.com.tw/avatars/{sub}" }`。
+3. **D1**：前端用回傳的 URL 做 `PATCH tables/users/:id`，只存 `avatar_url: "https://boardgamematch.com.tw/avatars/xxx"`，不再存整段 base64。
+4. **讀取**：其他玩家或排行榜載入 `https://boardgamematch.com.tw/avatars/xxx` → 入口 Worker 轉給 API Worker → 從 R2 讀取並回傳圖片（公開、可快取）。
+
+---
+
+## 4. 部署
+
+```bash
+cd cloudflare
+# 1. 部署 API Worker（含 R2 綁定）
+npx wrangler deploy -c wrangler.toml
+
+# 2. 部署入口 Worker（轉發 /api、/avatars）
+npx wrangler deploy -c wrangler-entry.toml
+```
+
+---
+
+## 5. 既有使用者
+
+- 已存成 data URL 的舊頭貼仍可正常顯示（`<img src="data:...">` 照樣能用）。
+- 下次在個人頁**重新儲存簡介或換頭貼**時，若選的是自訂圖片（data URL），會先上傳到 R2，之後 D1 就會變成存新 URL。
+
+若要批次把舊 data URL 搬上 R2，需要另寫腳本：讀出每個 user 的 `avatar_url`，若為 data URL 則上傳到 R2 再更新該筆 `avatar_url`（需後台或一次性腳本）。

--- a/public/profile.html
+++ b/public/profile.html
@@ -2271,7 +2271,7 @@
                 <h2 style="margin-bottom: 1rem; color: var(--text-color); font-size: 1.5rem;">🎯 選擇你的 MBTI 類型</h2>
                 <div style="background:#fff3cd;border:1px solid #ffc107;border-radius:0.6rem;padding:0.75rem 1rem;margin-bottom:1rem;font-size:0.88rem;color:#856404;">
                     💡 請選擇你的 MBTI 類型，之後仍可隨時更改。<br>
-                    <span style="font-size:0.82rem;">還不確定？<a href="https://www.16personalities.com/tw" target="_blank" style="color:#856404;font-weight:600;">點此測驗 →</a></span>
+                    <span style="font-size:0.82rem;">還不確定？<a href="personality-test.html" style="color:#856404;font-weight:600;">到桌友適性測驗 →</a></span>
                 </div>
                 <div id="mbti-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem;">
                     ${Object.entries(mbtiTypes).map(([type, info]) => `
@@ -3289,9 +3289,9 @@
             const file = event.target.files?.[0];
             if (!file) return;
 
-            // 限制大小：最大 5MB（裁切後會壓縮）
-            if (file.size > 5 * 1024 * 1024) {
-                alert('圖片太大了！請選擇 5MB 以內的圖片。');
+            // 限制大小：最大 3MB
+            if (file.size > 3 * 1024 * 1024) {
+                alert('圖片太大了！請選擇 3MB 以內的圖片。');
                 event.target.value = '';
                 return;
             }
@@ -3556,8 +3556,14 @@
                         offsetX * ratio, offsetY * ratio,
                         img.width * scale * ratio, img.height * scale * ratio);
                     const compressed = out.toDataURL('image/jpeg', 0.75);
-                    // base64 大小檢查（約 200x200 JPEG 0.75 ≈ 15–25KB）
-                    console.log(`📸 頭貼大小：${Math.round(compressed.length / 1024)}KB`);
+                    const prefixLen = compressed.indexOf(',') + 1;
+                    const byteSize = Math.ceil((compressed.length - prefixLen) * 3 / 4);
+                    const MAX_AVATAR_BYTES = 3 * 1024 * 1024; // 3MB
+                    if (byteSize > MAX_AVATAR_BYTES) {
+                        alert('頭貼不得超過 3MB，目前約 ' + (byteSize / 1024 / 1024).toFixed(2) + 'MB。請縮小圖片或降低畫質後再試。');
+                        return;
+                    }
+                    console.log(`📸 頭貼大小：${Math.round(byteSize / 1024)}KB`);
 
                     // 套用到 pending + 更新 bio modal 預覽
                     _bioAvatarPending = { url: compressed, name: '自訂圖片', emoji: null, color: null };
@@ -3601,13 +3607,29 @@
                 const patchBody = { social_links: JSON.stringify(socialLinks), bio: bioText };
                 if (nickname) patchBody.username = nickname;
 
-                // 如有選新頭貼，先存 localStorage，並加入 PATCH body
+                // 如有選新頭貼：若為 data URL（自訂上傳），先上傳到 R2 取得公開 URL，再寫入 D1
                 if (_bioAvatarPending) {
+                    let avatarUrlToSave = _bioAvatarPending.url;
+                    if (typeof avatarUrlToSave === 'string' && avatarUrlToSave.startsWith('data:image/')) {
+                        const token = localStorage.getItem('google_id_token');
+                        if (!token) throw new Error('請重新登入後再上傳頭貼');
+                        const uploadRes = await fetch('/api/upload-avatar', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+                            body: JSON.stringify({ image: avatarUrlToSave }),
+                        });
+                        if (!uploadRes.ok) {
+                            const err = await uploadRes.json().catch(() => ({}));
+                            throw new Error(err.error || '頭貼上傳失敗，請稍後再試');
+                        }
+                        const data = await uploadRes.json();
+                        avatarUrlToSave = data.url || avatarUrlToSave;
+                    }
                     const userId = currentUser?.google_id || currentUser?.id;
-                    localStorage.setItem(`avatar_${userId}`, _bioAvatarPending.url);
-                    document.getElementById('profile-avatar').src = _bioAvatarPending.url;
-                    patchBody.avatar_url = _bioAvatarPending.url;
-                    currentUser.avatar_url = _bioAvatarPending.url;
+                    localStorage.setItem(`avatar_${userId}`, avatarUrlToSave);
+                    document.getElementById('profile-avatar').src = avatarUrlToSave;
+                    patchBody.avatar_url = avatarUrlToSave;
+                    currentUser.avatar_url = avatarUrlToSave;
                 }
 
                 // safePatch 到資料庫


### PR DESCRIPTION
- API Worker: POST /api/upload-avatar、GET /avatars/:userId，R2 綁定
- 入口 Worker: 轉發 /api/*、/avatars/*
- profile: 上傳時先送 R2 再 PATCH avatar_url，選檔/裁切/後端皆限制 3MB
- docs: R2-avatar-setup.md 設定教學

Made-with: Cursor